### PR TITLE
Parse torrent category number from category link

### DIFF
--- a/lib/pirata/search.rb
+++ b/lib/pirata/search.rb
@@ -101,7 +101,7 @@ module Pirata
           h[:seeders]     = row.search('td')[2].text.to_i
           h[:leechers]    = row.search('td')[3].text.to_i
           h[:uploader]    = Pirata::User.new(row.search('.detDesc a')[0].text)
-          h[:category_num] = category
+          h[:category_num] = category_num
         rescue
           #puts "not found"
         end

--- a/lib/pirata/search.rb
+++ b/lib/pirata/search.rb
@@ -87,6 +87,10 @@ module Pirata
         next if title == ''
         h = {}
 
+        category_num = row.search('td:nth-child(1) a').map do |a|
+          %r(/browse/(\d+)).match(a['href'])&.match(1)
+        end.compact.max
+
         begin
           h[:title]       = title
           h[:category]    = row.search('td a')[0].text
@@ -97,6 +101,7 @@ module Pirata
           h[:seeders]     = row.search('td')[2].text.to_i
           h[:leechers]    = row.search('td')[3].text.to_i
           h[:uploader]    = Pirata::User.new(row.search('.detDesc a')[0].text)
+          h[:category_num] = category
         rescue
           #puts "not found"
         end

--- a/lib/pirata/torrent.rb
+++ b/lib/pirata/torrent.rb
@@ -6,7 +6,7 @@ require 'time'
 module Pirata
   class Torrent
 
-    attr_reader :title, :category, :url, :id, :magnet
+    attr_reader :title, :category, :category_num, :url, :id, :magnet
 
     def initialize(params_hash)
       @params     = params_hash
@@ -15,6 +15,7 @@ module Pirata
       @url        = @params[:url]
       @id         = @params[:id]
       @magnet     = @params[:magnet]
+      @category_num = @params[:category_num]
 
       build_getters()
     end
@@ -32,7 +33,7 @@ module Pirata
 
     def update_params!
       html = Pirata::Torrent.parse_html(url)
-      
+
       updated_params = Pirata::Torrent.parse_torrent_page(html)
       @params.merge!(updated_params)
     end

--- a/test/test_pirata.rb
+++ b/test/test_pirata.rb
@@ -64,6 +64,7 @@ class PirataTest < Minitest::Unit::TestCase
     torrent = Pirata::Search.new("zelda").results.first
     assert_equal(String, torrent.title.class)
     assert_equal(String, torrent.category.class)
+    assert_equal(String, torrent.category_num.class)
     assert(!/http.*/.match(torrent.url).nil?)
     assert_equal(Fixnum, torrent.id.class)
     assert(!/magnet:\?.*/.match(torrent.magnet).nil?)


### PR DESCRIPTION
Torrent HTML has links to group (e.g. "Audio") and category (e.g. "Music").  Existing `category` field has group name, this uses the larger number to get category for `category_num`.